### PR TITLE
Added options to force client side window decorations

### DIFF
--- a/data/SettingsDialog.ui
+++ b/data/SettingsDialog.ui
@@ -229,7 +229,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -239,6 +239,34 @@
                             <property name="halign">end</property>
                             <property name="hexpand">True</property>
                             <signal name="state-set" handler="_update_genres_setting" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="csd">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_right">50</property>
+                            <property name="margin_end">50</property>
+                            <property name="label" translatable="yes">Force CSDs (headerbars)</property>
+                            <property name="ellipsize">end</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="switch_csd">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <signal name="state-set" handler="_update_csd_setting" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>

--- a/data/org.gnome.Lollypop.gschema.xml
+++ b/data/org.gnome.Lollypop.gschema.xml
@@ -63,6 +63,11 @@
             <summary>Use dark gtk theme</summary>
             <description></description>
         </key>
+         <key type="b" name="force-csd">
+            <default>false</default>
+            <summary>Force the use client side window decorations (headerbar)</summary>
+            <description>If set to true CSD headerbars will be used, even if the detected desktop environment is not amongst those that are expected to support it.</description>
+        </key>
 		 <key type="b" name="stylized-covers">
             <default>true</default>
             <summary>Show stylized covers</summary>

--- a/src/settings.py
+++ b/src/settings.py
@@ -41,6 +41,9 @@ class SettingsDialog:
         switch_view = builder.get_object('switch_dark')
         switch_view.set_state(Objects.settings.get_value('dark-ui'))
 
+        switch_csd = builder.get_object('switch_csd')
+        switch_csd.set_state(Objects.settings.get_value('force-csd'))
+
         switch_background = builder.get_object('switch_background')
         switch_background.set_state(Objects.settings.get_value(
                                                     'background-mode'))
@@ -147,6 +150,14 @@ class SettingsDialog:
         if not Objects.player.is_party():
             settings = Gtk.Settings.get_default()
             settings.set_property("gtk-application-prefer-dark-theme", state)
+
+    """
+        Update CSD setting
+        @param widget as unused, state as widget state
+    """
+    def _update_csd_setting(self, widget, state):
+        Objects.settings.set_value('force-csd',
+                                   GLib.Variant('b', state))
 
     """
         Update scan setting

--- a/src/settings.py
+++ b/src/settings.py
@@ -14,7 +14,7 @@
 from gi.repository import Gtk, GLib
 
 from lollypop.define import Objects
-from lollypop.utils import is_gnome, is_eos
+from lollypop.utils import use_csd
 
 
 # Dialog showing lollypop options
@@ -31,7 +31,7 @@ class SettingsDialog:
         self._settings_dialog = builder.get_object('settings_dialog')
         self._settings_dialog.set_transient_for(parent)
 
-        if is_gnome() or is_eos():
+        if use_csd():
             self._settings_dialog.set_titlebar(
                                 builder.get_object('header_bar'))
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,6 +12,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import Gio
+
+from lollypop.define import Objects
 from gettext import gettext as _
 import os
 
@@ -27,10 +29,14 @@ def is_eos():
     Return True if desktop is Gnome
 """
 
-
 def is_gnome():
     return os.environ.get("XDG_CURRENT_DESKTOP") == "GNOME"
 
+"""
+    Return True if CSDs are to be used based on several criterions
+"""
+def use_csd():
+    return is_gnome() or is_eos() or Objects.settings.get_value('force-csd')
 
 """
     Return True if files is audio

--- a/src/window.py
+++ b/src/window.py
@@ -16,7 +16,7 @@ from gi.repository import Gtk, Gio, GLib
 from lollypop.container import Container
 from lollypop.define import Objects
 from lollypop.toolbar import Toolbar
-from lollypop.utils import is_gnome, is_eos
+from lollypop.utils import use_csd
 
 
 # Main window
@@ -122,7 +122,7 @@ class Window(Gtk.ApplicationWindow, Container):
         self._toolbar.header_bar.show()
 
         # Only set headerbar on Gnome Shell and Pantheon Shell
-        if is_gnome() or is_eos():
+        if use_csd():
             self.set_titlebar(self._toolbar.header_bar)
             self._toolbar.header_bar.set_show_close_button(True)
             self.add(self.main_widget())

--- a/src/window.py
+++ b/src/window.py
@@ -121,7 +121,7 @@ class Window(Gtk.ApplicationWindow, Container):
         self._toolbar = Toolbar(self.get_application())
         self._toolbar.header_bar.show()
 
-        # Only set headerbar on Gnome Shell and Pantheon Shell
+        # Only set headerbar if according DE detected or forced manually
         if use_csd():
             self.set_titlebar(self._toolbar.header_bar)
             self._toolbar.header_bar.set_show_close_button(True)


### PR DESCRIPTION
Gnome and Pantheon are not the only desktop environments with support for client side window decorations. Installing *Lollypop* on my Xfce + Compiz Arch setup, I was very disappointed because I didn't find the nice, modern headerbar that I expected to see.

Even without a fancy WM like Compiz, Xfce [can handle CSDs nowadays](http://www.xfce.org/about/news/?post=1425081600).

That's why I implemented an option to force CSDs, even if `XDG_CURRENT_DESKTOP` is neither `"GNOME"` nor `"Pantheon"`.

I gave my best to adapt your coding style and hope that the pull request is to your liking :wink:

I really like the project - keep up the good work :+1: 
