### PR TITLE
Removed slow search for existing selectionlist items

### DIFF
--- a/src/container.py
+++ b/src/container.py
@@ -547,8 +547,8 @@ class Container:
     """
     def _on_list_one_selected(self, selection_list, selected_id):
         if selected_id == Type.PLAYLISTS:
-            start_new_thread(self._setup_list_playlists, (False,))
             self._list_two.clear()
+            start_new_thread(self._setup_list_playlists, (False,))
             self._list_two.show()
             if not self._list_two.will_be_selected():
                 self._update_view_playlists(None)

--- a/src/selectionlist.py
+++ b/src/selectionlist.py
@@ -12,8 +12,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import Gtk, GLib, GObject, Pango, cairo
-from time import time
-from _thread import start_new_thread
 
 from lollypop.utils import format_artist_name
 from lollypop.define import Type, Lp
@@ -128,8 +126,11 @@ class SelectionList(Gtk.ScrolledWindow):
         @thread safe
     """
     def populate(self, values):
-        self._pop_time = time()
-        start_new_thread(self._populate, (values,))
+        if len(self._model) > 0:
+            self._updating = True
+        self._add_values(values)
+        self.emit("populated")
+        self._updating = False
 
     """
         Remove row from model
@@ -156,18 +157,16 @@ class SelectionList(Gtk.ScrolledWindow):
     """
     def update_values(self, values):
         self._updating = True
+        # Remove not found items but not devices
+        value_ids = set([v[0] for v in values])
         for item in self._model:
-            found = False
-            for value in values:
-                if item[1] == value[1]:
-                    found = True
-                    break
-            # Remove not found items but not devices
-            if not found and item[0] > Type.DEVICES:
+            if item[0] > Type.DEVICES and not item[0] in value_ids:
                 self._model.remove(item.iter)
-
+        # Add items which are not already in the list
+        item_ids = set([i[0] for i in self._model])
         for value in values:
-            self._add_value(value)
+            if not value[0] in item_ids:
+                self._add_value(value)
         self._updating = False
 
     """
@@ -243,49 +242,17 @@ class SelectionList(Gtk.ScrolledWindow):
         @param value as [int, str]
     """
     def _add_value(self, value):
-        found = False
-        for item in self._model:
-            if value[0] == item[0]:
-                found = True
-                break
-        if not found:
-            self._model.append([value[0],
-                                value[1],
-                                self._get_icon_name(value[0])])
-            if value[0] == self._to_select_id:
-                self.select_id(self._to_select_id)
-
-    """
-        Populate view with values
-        @param [(int, str)], will be deleted
-        @thread safe
-    """
-    def _populate(self, values):
-        if len(self._model) > 0:
-            self._updating = True
-        GLib.idle_add(self._add_values, values, self._pop_time)
+        self._model.append([value[0], value[1], self._get_icon_name(value[0])])
+        if value[0] == self._to_select_id:
+            self.select_id(self._to_select_id)
 
     """
         Add values to the list
         @param items as [(int,str)]
-        @param time as float
     """
-    def _add_values(self, values, time):
-        if time != self._pop_time:
-            del values
-            values = None
-            return
-        elif not values:
-            self.emit("populated")
-            self._updating = False
-            del values
-            values = None
-            self._pop_time = 0
-            return
-
-        value = values.pop(0)
-        self._add_value(value)
-        GLib.idle_add(self._add_values, values, time)
+    def _add_values(self, values):
+        for value in values:
+            self._add_value(value)
 
     """
         Return pixbuf for id


### PR DESCRIPTION
When the selectionlist is filled with more than just a few items (445 artists in my case) they appear really slowly in the UI. This is caused by a slow search for existing items. In `update_values` there are `len(self._model) * len(values)` comparisons. This method also calls `add_value` which looks for existing items again. So `2 * len(self._model) * len(values)` comparisons in total. 

My changes instead create a set of item ids and look up ids of new items there. I also removed the unnecessary thread for `populate` and simplified `add_values`. 