### PR TITLE
Removed most threading from GTK widgets

### DIFF
--- a/src/pop_externals.py
+++ b/src/pop_externals.py
@@ -12,8 +12,6 @@
 
 from gi.repository import Gtk, GLib, Pango
 
-from _thread import start_new_thread
-
 from lollypop.define import Lp
 from lollypop.tagreader import ScannerTagReader
 from lollypop.utils import seconds_to_string
@@ -67,7 +65,7 @@ class ExternalsPopover(Gtk.Popover):
             Populate popover
         """
         self._model.clear()
-        start_new_thread(self._populate, (Lp.player.get_externals(),))
+        self._populate(Lp.player.get_externals())
 
     def do_show(self):
         """

--- a/src/pop_infos.py
+++ b/src/pop_infos.py
@@ -211,7 +211,7 @@ class ArtistInfos(Gtk.Bin):
             self._url_btn.set_uri(url)
             self._content.set_text(content)
             if self._track_id is not None:
-                start_new_thread(self._show_love_btn, ())
+                self._show_love_btn()
             if self._wikipedia:
                 self._view_btn.set_tooltip_text(_("Wikipedia"))
                 self._url_btn.set_label(_("Last.fm"))
@@ -246,7 +246,7 @@ class ArtistInfos(Gtk.Bin):
                 self._love_btn.set_image(
                     Gtk.Image.new_from_icon_name('face-sick-symbolic',
                                                  Gtk.IconSize.BUTTON))
-        GLib.idle_add(self._love_btn.show)
+        self._love_btn.show()
         sql.close()
 
     def _love_track(self):
@@ -289,14 +289,14 @@ class ArtistInfos(Gtk.Bin):
             @param btn as Gtk.Button
         """
         if self._liked:
-            start_new_thread(self._love_track, ())
+            self._love_track()
             btn.set_image(
                 Gtk.Image.new_from_icon_name('face-sick-symbolic',
                                              Gtk.IconSize.BUTTON))
             self._liked = False
             btn.set_tooltip_text(_("I do not love"))
         else:
-            start_new_thread(self._unlove_track, ())
+            self._unlove_track()
             btn.set_image(
                 Gtk.Image.new_from_icon_name('emblem-favorite-symbolic',
                                              Gtk.IconSize.BUTTON))

--- a/src/selectionlist.py
+++ b/src/selectionlist.py
@@ -137,7 +137,7 @@ class SelectionList(Gtk.ScrolledWindow):
         if len(self._model) > 0:
             self._updating = True
         self._add_values(values)
-        GLib.idle_add(self.emit, 'populated')
+        self.emit('populated')
         self._updating = False
 
     def remove(self, object_id):
@@ -170,16 +170,12 @@ class SelectionList(Gtk.ScrolledWindow):
         value_ids = set([v[0] for v in values])
         for item in self._model:
             if item[0] > Type.DEVICES and not item[0] in value_ids:
-                Gdk.threads_enter()
                 self._model.remove(item.iter)
-                Gdk.threads_leave()
         # Add items which are not already in the list
         item_ids = set([i[0] for i in self._model])
         for value in values:
             if not value[0] in item_ids:
-                Gdk.threads_enter()
                 self._add_value(value)
-                Gdk.threads_leave()
         self._updating = False
 
     def get_value(self, object_id):
@@ -254,7 +250,7 @@ class SelectionList(Gtk.ScrolledWindow):
                             value[1],
                             self._get_icon_name(value[0])])
         if value[0] == self._to_select_id:
-            GLib.idle_add(self.select_id, self._to_select_id)
+            self.select_id(self._to_select_id)
 
     def _add_values(self, values):
         """
@@ -263,9 +259,7 @@ class SelectionList(Gtk.ScrolledWindow):
             @thread safe
         """
         for value in values:
-            Gdk.threads_enter()
             self._add_value(value)
-            Gdk.threads_leave()
 
     def _get_icon_name(self, object_id):
         """

--- a/src/view_albums.py
+++ b/src/view_albums.py
@@ -12,8 +12,6 @@
 
 from gi.repository import Gtk, GLib, Gdk
 
-from _thread import start_new_thread
-
 from lollypop.view import View
 from lollypop.pop_infos import InfosPopover
 from lollypop.view_container import ViewContainer
@@ -58,39 +56,16 @@ class ArtistView(View):
         self._viewport.add(self._albumbox)
         self.add(self._scrolledWindow)
 
-    def populate(self):
+    def populate(self, albums):
         """
             Populate the view
-            @thread safe
         """
-        albums = self._get_albums()
-        GLib.idle_add(self._add_albums, albums, self._genre_id)
+        self._add_albums(albums, self._genre_id)
 
 
 #######################
 # PRIVATE             #
 #######################
-    def _get_albums(self):
-        """
-            Get albums
-            @return album ids as [int]
-            @thread safe
-        """
-        sql = Lp.db.get_cursor()
-        if self._artist_id == Type.COMPILATIONS:
-            albums = Lp.albums.get_compilations(self._genre_id,
-                                                sql)
-        elif self._genre_id == Type.ALL:
-            albums = Lp.albums.get_ids(self._artist_id,
-                                       None,
-                                       sql)
-        else:
-            albums = Lp.albums.get_ids(self._artist_id,
-                                       self._genre_id,
-                                       sql)
-        sql.close()
-        return albums
-
     def _get_children(self):
         """
             Return view children
@@ -113,7 +88,7 @@ class ArtistView(View):
                                          False,
                                          size_group)
             widget.show()
-            start_new_thread(widget.populate, ())
+            widget.populate()
             self._albumbox.add(widget)
             GLib.idle_add(self._add_albums, albums, genre_id)
         else:
@@ -218,14 +193,12 @@ class AlbumsView(View):
         self._paned.show()
         self.add(self._paned)
 
-    def populate(self):
+    def populate(self, albums):
         """
             Populate albums
             @param is compilation as bool
-            @thread safe
         """
-        albums = self._get_albums()
-        GLib.idle_add(self._add_albums, albums)
+        self._add_albums(albums)
 
 #######################
 # PRIVATE             #
@@ -285,7 +258,7 @@ class AlbumsView(View):
                                                    True,
                                                    True,
                                                    size_group)
-        start_new_thread(self._context_widget.populate, ())
+        self._context_widget.populate()
         self._context_widget.show()
         view = AlbumContextView(self._context_widget)
         view.show()

--- a/src/view_device.py
+++ b/src/view_device.py
@@ -12,7 +12,6 @@
 
 from gi.repository import Gtk, GLib, Gio
 
-from _thread import start_new_thread
 from gettext import gettext as _
 
 from lollypop.view import View
@@ -120,7 +119,7 @@ class DeviceView(View):
         uri = "%s%s/Music/%s" % (self._device.uri, text, "lollypop")
         on_disk_playlists = self._get_files(uri)
         self._device_widget.set_playlists(on_disk_playlists, uri)
-        start_new_thread(self._device_widget.populate, ())
+        self._device_widget.populate()
 
     def _set_combo_text(self, text_list):
         """

--- a/src/view_playlists.py
+++ b/src/view_playlists.py
@@ -12,8 +12,6 @@
 
 from gi.repository import Gtk
 
-from _thread import start_new_thread
-
 from lollypop.view import View
 from lollypop.widgets_playlist import PlaylistWidget, PlaylistEditWidget
 from lollypop.widgets_playlist import PlaylistsManagerWidget
@@ -55,19 +53,20 @@ class PlaylistView(View):
         self._scrolledWindow.set_property('expand', True)
         self.add(self._scrolledWindow)
 
-    def populate(self):
+    def populate(self, tracks=None):
         """
             Populate view with tracks from playlist
             Thread safe
         """
-        sql = Lp.db.get_cursor()
-        tracks = Lp.playlists.get_tracks_id(self._playlist_name, sql)
-        mid_tracks = int(0.5+len(tracks)/2)
-        self._playlist_widget.populate_list_left(tracks[:mid_tracks],
-                                                1)
-        self._playlist_widget.populate_list_right(tracks[mid_tracks:],
-                                                mid_tracks + 1)
-        sql.close()
+        if tracks:
+            self.populate_tracks(tracks)
+        else:
+            tracks = Lp.playlists.get_tracks_id(self._playlist_name)
+            mid_tracks = int(0.5+len(tracks)/2)
+            self._playlist_widget.populate_list_left(tracks[:mid_tracks],
+                                                    1)
+            self._playlist_widget.populate_list_right(tracks[mid_tracks:],
+                                                    mid_tracks + 1)
 
     def populate_tracks(self, tracks):
         """
@@ -121,7 +120,7 @@ class PlaylistView(View):
         """
         if playlist_name == self._playlist_name:
             self._playlist_widget.clear()
-            start_new_thread(self.populate, ())
+            self.populate()
 
     def _on_edit_btn_clicked(self, button):
         """

--- a/src/widgets_device.py
+++ b/src/widgets_device.py
@@ -81,7 +81,7 @@ class DeviceManagerWidget(Gtk.Bin, MtpSync):
         self._model.clear()
         playlists = [(Type.LOVED, Lp.playlists._LOVED)]
         playlists += Lp.playlists.get()
-        GLib.idle_add(self._append_playlists, playlists)
+        self._append_playlists(playlists)
 
     def set_playlists(self, playlists, uri):
         """

--- a/src/widgets_playlist.py
+++ b/src/widgets_playlist.py
@@ -498,7 +498,7 @@ class PlaylistEditWidget(Gtk.Bin):
             populate view if needed
         """
         if len(self._model) == 0:
-            start_new_thread(self._append_tracks, ())
+            self._append_tracks()
 
 #######################
 # PRIVATE             #
@@ -512,11 +512,10 @@ class PlaylistEditWidget(Gtk.Bin):
 
     def _append_tracks(self):
         """
-            Append tracks, thread safe
+            Append tracks
         """
-        sql = Lp.db.get_cursor()
-        tracks = Lp.playlists.get_tracks_id(self._playlist_name, sql)
-        GLib.idle_add(self._append_track, tracks)
+        tracks = Lp.playlists.get_tracks_id(self._playlist_name)
+        self._append_track(tracks)
 
     def _append_track(self, tracks):
         """


### PR DESCRIPTION
This is an effort to make the custom GTK widgets simpler by removing threading-related code. Where possible, I moved code to `container.py` which uses the class `Loader` to load data in a new thread and to dispatch results to the UI thread. 

I'm not done with theses changes, but since it affects so many files it would be great to merge this with the master to keep conflicts to a minimum. Some widgets load data synchronously for now, but it's very responsive for me. 