### PR TITLE
Fixed LastFM not showing the album cover

### DIFF
--- a/src/lastfm.py
+++ b/src/lastfm.py
@@ -130,11 +130,12 @@ class LastFM(LastFMNetwork):
         except:
             return (None, None, None)
 
-    def scrobble(self, artist, title, timestamp, duration):
+    def scrobble(self, artist, title, timestamp, duration, album=None):
         """
             Scrobble track
             @param artist as str
             @param title as str
+            @param album as str
             @param timestamp as int
             @param duration as int
         """
@@ -143,20 +144,23 @@ class LastFM(LastFMNetwork):
             start_new_thread(self._scrobble, (artist,
                                               title,
                                               timestamp,
-                                              duration))
+                                              duration,
+                                              album))
 
-    def now_playing(self, artist, title, duration):
+    def now_playing(self, artist, title, duration, album=None):
         """
             Now playing track
             @param artist as str
             @param title as str
+            @param album as str
             @param duration as int
         """
         if Gio.NetworkMonitor.get_default().get_network_available() and\
            self._is_auth and Secret is not None:
             start_new_thread(self._now_playing, (artist,
                                                  title,
-                                                 duration))
+                                                 duration,
+                                                 album))
 
     def love(self, artist, title):
         """
@@ -236,34 +240,38 @@ class LastFM(LastFMNetwork):
             print("Lastfm::_connect(): %s" % e)
         self._populate_loved_tracks()
 
-    def _scrobble(self, artist, title, timestamp, duration):
+    def _scrobble(self, artist, title, timestamp, duration, album=None):
         """
             Scrobble track
             @param artist as str
             @param title as str
+            @param album_title as str
             @param timestamp as int
             @param duration as int
             @thread safe
         """
-        debug("LastFM::_scrobble(): %s, %s, %s, %s" % (artist,
+        debug("LastFM::_scrobble(): %s, %s, %s, %s, %s" % (artist,
                                                        title,
                                                        timestamp,
-                                                       duration))
+                                                       duration,
+                                                       album))
         try:
             LastFMNetwork.scrobble(self,
                                    artist=artist,
                                    title=title,
-                                   timestamp=timestamp)
+                                   timestamp=timestamp,
+                                   album=album)
         except BadAuthenticationError:
             pass
         except:
             self._connect(self._username, self._password)
 
-    def _now_playing(self, artist, title, duration, first=True):
+    def _now_playing(self, artist, title, duration, first=True, album=None):
         """
             Now playing track
             @param artist as str
             @param title as str
+            @param album as str
             @param duration as int
             @param first is internal
             @thread safe
@@ -275,7 +283,8 @@ class LastFM(LastFMNetwork):
             LastFMNetwork.update_now_playing(self,
                                              artist=artist,
                                              title=title,
-                                             duration=duration)
+                                             duration=duration,
+                                             album=album)
         except BadAuthenticationError:
             if Lp.notify is not None:
                 GLib.idle_add(Lp.notify.send, _("Wrong Last.fm credentials"))
@@ -283,7 +292,7 @@ class LastFM(LastFMNetwork):
             # now playing sometimes fails
             if first:
                 self._connect(self._username, self._password)
-                self._now_playing(artist, title, duration, False)
+                self._now_playing(artist, title, duration, False, album)
 
     def _download_albums_imgs(self):
         """

--- a/src/lastfm.py
+++ b/src/lastfm.py
@@ -130,7 +130,7 @@ class LastFM(LastFMNetwork):
         except:
             return (None, None, None)
 
-    def scrobble(self, artist, title, timestamp, duration, album=None):
+    def scrobble(self, artist, album, title, timestamp, duration):
         """
             Scrobble track
             @param artist as str
@@ -142,12 +142,12 @@ class LastFM(LastFMNetwork):
         if Gio.NetworkMonitor.get_default().get_network_available() and\
            self._is_auth and Secret is not None:
             start_new_thread(self._scrobble, (artist,
+                                              album,
                                               title,
                                               timestamp,
-                                              duration,
-                                              album))
+                                              duration))
 
-    def now_playing(self, artist, title, duration, album=None):
+    def now_playing(self, artist, album, title, duration):
         """
             Now playing track
             @param artist as str
@@ -158,9 +158,9 @@ class LastFM(LastFMNetwork):
         if Gio.NetworkMonitor.get_default().get_network_available() and\
            self._is_auth and Secret is not None:
             start_new_thread(self._now_playing, (artist,
+                                                 album,
                                                  title,
-                                                 duration,
-                                                 album))
+                                                 duration))
 
     def love(self, artist, title):
         """
@@ -240,7 +240,7 @@ class LastFM(LastFMNetwork):
             print("Lastfm::_connect(): %s" % e)
         self._populate_loved_tracks()
 
-    def _scrobble(self, artist, title, timestamp, duration, album=None):
+    def _scrobble(self, artist, album, title, timestamp, duration):
         """
             Scrobble track
             @param artist as str
@@ -251,22 +251,22 @@ class LastFM(LastFMNetwork):
             @thread safe
         """
         debug("LastFM::_scrobble(): %s, %s, %s, %s, %s" % (artist,
+                                                       album,
                                                        title,
                                                        timestamp,
-                                                       duration,
-                                                       album))
+                                                       duration))
         try:
             LastFMNetwork.scrobble(self,
                                    artist=artist,
+                                   album=album,
                                    title=title,
-                                   timestamp=timestamp,
-                                   album=album)
+                                   timestamp=timestamp)
         except BadAuthenticationError:
             pass
         except:
             self._connect(self._username, self._password)
 
-    def _now_playing(self, artist, title, duration, first=True, album=None):
+    def _now_playing(self, artist, album, title, duration, first=True):
         """
             Now playing track
             @param artist as str
@@ -276,15 +276,16 @@ class LastFM(LastFMNetwork):
             @param first is internal
             @thread safe
         """
-        debug("LastFM::_now_playing(): %s, %s, %s" % (artist,
+        debug("LastFM::_now_playing(): %s, %s, %s, %s" % (artist,
+                                                      album,
                                                       title,
                                                       duration))
         try:
             LastFMNetwork.update_now_playing(self,
                                              artist=artist,
+                                             album=album,
                                              title=title,
-                                             duration=duration,
-                                             album=album)
+                                             duration=duration)
         except BadAuthenticationError:
             if Lp.notify is not None:
                 GLib.idle_add(Lp.notify.send, _("Wrong Last.fm credentials"))
@@ -292,7 +293,7 @@ class LastFM(LastFMNetwork):
             # now playing sometimes fails
             if first:
                 self._connect(self._username, self._password)
-                self._now_playing(artist, title, duration, False, album)
+                self._now_playing(artist, album, title, duration, False)
 
     def _download_albums_imgs(self):
         """

--- a/src/player_bin.py
+++ b/src/player_bin.py
@@ -323,7 +323,8 @@ class BinPlayer(ReplayGainPlayer, BasePlayer):
                 Lp.lastfm.scrobble(artist,
                                    finished.title,
                                    int(finished_start_time),
-                                   int(finished.duration))
+                                   int(finished.duration),
+                                   finished.album_name)
 
         sql.close()
 
@@ -346,7 +347,8 @@ class BinPlayer(ReplayGainPlayer, BasePlayer):
                 artist = self.current_track.album_artist
                 Lp.lastfm.now_playing(artist,
                                       self.current_track.title,
-                                      int(self.current_track.duration))
+                                      int(self.current_track.duration),
+                                      self.current_track.album_name)
         if not Lp.scanner.is_locked():
             Lp.tracks.set_listened_at(self.current_track.id, int(time()))
         self._handled_error = None

--- a/src/player_bin.py
+++ b/src/player_bin.py
@@ -321,10 +321,10 @@ class BinPlayer(ReplayGainPlayer, BasePlayer):
                 artist = finished.album_artist
             if time() - finished_start_time > 30:
                 Lp.lastfm.scrobble(artist,
+                                   finished.album_name,
                                    finished.title,
                                    int(finished_start_time),
-                                   int(finished.duration),
-                                   finished.album_name)
+                                   int(finished.duration))
 
         sql.close()
 
@@ -346,9 +346,9 @@ class BinPlayer(ReplayGainPlayer, BasePlayer):
             else:
                 artist = self.current_track.album_artist
                 Lp.lastfm.now_playing(artist,
+                                      self.current_track.album_name,
                                       self.current_track.title,
-                                      int(self.current_track.duration),
-                                      self.current_track.album_name)
+                                      int(self.current_track.duration))
         if not Lp.scanner.is_locked():
             Lp.tracks.set_listened_at(self.current_track.id, int(time()))
         self._handled_error = None


### PR DESCRIPTION
When scrobbling or updating the current track being played, Lollypop didn't specified the album name, so LastFM scrobbled songs without linking them to an album, therefor, not showing the album cover in the profile.

This should fix it, since I changed the lastfm.py file to take an additional parameter in both scrobble() and now_playing() which has a default value of None (like the default value of the scrobble function on pylast when no album is specified).

Also updated the player_bin.py file to give the album name to both functions. I don't know if I left anything behind, but I tested it and it works like charm.