### PR TITLE
Add loved button to track list

### DIFF
--- a/data/LovedWidget.ui
+++ b/data/LovedWidget.ui
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <object class="GtkGrid" id="widget">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="halign">center</property>
+    <child>
+      <object class="GtkEventBox" id="eventbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <signal name="button-press-event" handler="_on_button_press" swapped="no"/>
+        <child>
+          <object class="GtkImage" id="loved">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">emblem-favorite-symbolic</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/data/TrackRow.ui
+++ b/data/TrackRow.ui
@@ -9,6 +9,13 @@
     <property name="icon_name">open-menu-symbolic</property>
     <property name="icon_size">2</property>
   </object>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="opacity">0.20000000000000001</property>
+    <property name="icon_name">emblem-favorite</property>
+    <property name="icon_size">2</property>
+  </object>
   <object class="GtkEventBox" id="row">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -19,13 +26,26 @@
         <property name="can_focus">False</property>
         <property name="margin_start">10</property>
         <child>
+          <object class="GtkImage" id="icon">
+            <property name="width_request">16</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="icon_size">1</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkButton" id="menu">
             <property name="width_request">42</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
             <property name="valign">center</property>
-            <property name="margin_start">10</property>
             <property name="image">image1</property>
             <property name="relief">none</property>
             <property name="focus_on_click">False</property>
@@ -44,16 +64,27 @@
           </packing>
         </child>
         <child>
-          <object class="GtkImage" id="icon">
-            <property name="width_request">16</property>
+          <object class="GtkButton" id="loved">
+            <property name="width_request">42</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">start</property>
-            <property name="icon_size">1</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">center</property>
+            <property name="margin_start">10</property>
+            <property name="image">image2</property>
+            <property name="relief">none</property>
+            <property name="focus_on_click">False</property>
+            <property name="always_show_image">True</property>
+            <signal name="clicked" handler="_on_loved_btn_clicked" swapped="no"/>
+            <style>
+              <class name="loved-button"/>
+              <class name="track-loved-button"/>
+            </style>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
+            <property name="pack_type">end</property>
             <property name="position">1</property>
           </packing>
         </child>

--- a/data/TrackRow.ui
+++ b/data/TrackRow.ui
@@ -9,13 +9,6 @@
     <property name="icon_name">open-menu-symbolic</property>
     <property name="icon_size">2</property>
   </object>
-  <object class="GtkImage" id="image2">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="opacity">0.20000000000000001</property>
-    <property name="icon_name">emblem-favorite</property>
-    <property name="icon_size">2</property>
-  </object>
   <object class="GtkEventBox" id="row">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -64,22 +57,13 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButton" id="loved">
-            <property name="width_request">42</property>
+          <object class="GtkImage" id="loved">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="valign">center</property>
+            <property name="can_focus">False</property>
+            <property name="opacity">0.10000000000000001</property>
             <property name="margin_start">10</property>
-            <property name="image">image2</property>
-            <property name="relief">none</property>
-            <property name="focus_on_click">False</property>
-            <property name="always_show_image">True</property>
-            <signal name="clicked" handler="_on_loved_btn_clicked" swapped="no"/>
-            <style>
-              <class name="loved-button"/>
-              <class name="track-loved-button"/>
-            </style>
+            <property name="icon_name">emblem-favorite-symbolic</property>
+            <property name="icon_size">2</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/data/application.css
+++ b/data/application.css
@@ -31,6 +31,16 @@ GtkTreeView.separator {
     color: shade(@theme_bg_color, 0.9);
 }
 
+Gtk.ListBoxRow .loved-button {
+	border-color: transparent;
+	background-color: transparent;
+	color: transparent;
+}
+
+Gtk.ListBoxRow .loved-button:hover {
+	border-color: alpha(@theme_fg_color, 0.1);
+}
+
 Gtk.ListBoxRow .menu-button {
 	border-color: transparent;
 	background-color: transparent;
@@ -118,13 +128,28 @@ Gtk.ListBoxRow .menu-button:hover {
   	color: inherit;
 }
 
-.trackrowplaying .menu-button{
+.trackrowplaying .loved-button {
+	background-color: transparent;
+	border-color: transparent;
+	color: transparent;
+}
+
+.trackrowplaying:hover .loved-button {
+	border-color: transparent;
+	color: inherit;
+}
+
+.trackrowplaying:hover .loved-button:hover {
+	border-color: alpha(#000000, 0.1);
+}
+
+.trackrowplaying .menu-button {
 	background-color: transparent;
     border-color: transparent;
   	color: transparent;
 }
 
-.trackrowplaying:hover .menu-button{
+.trackrowplaying:hover .menu-button {
 	border-color: transparent;
   	color: inherit;
 }
@@ -133,14 +158,28 @@ Gtk.ListBoxRow .menu-button:hover {
 	border-color: alpha(#000000, 0.1);
 }
 
+.trackrow .loved-button {
+	border-color: transparent;
+	background-color: transparent;
+	color: transparent;
+}
+
 .trackrow .menu-button {
 	border-color: transparent;
 	background-color: transparent;
 	color: transparent;
 }
 
+.trackrow:hover .loved-button {
+	color: inherit;
+}
+
 .trackrow:hover .menu-button {
   	color: inherit;
+}
+
+.trackrow:hover .loved-button:hover {
+	border-color: alpha(@theme_fg_color, 0.1);
 }
 
 .trackrow:hover .menu-button:hover {
@@ -157,7 +196,12 @@ Gtk.ListBoxRow .menu-button:hover {
   	color: inherit;
 }
 
-.track-menu-selected .track-menu-button{
+.track-menu-selected .track-loved-button {
+	border-color: alpha(@theme_fg_color, 0.1);
+	color: inherit;
+}
+
+.track-menu-selected .track-menu-button {
 	border-color: alpha(@theme_fg_color, 0.1);
   	color: inherit;
 }
@@ -175,3 +219,15 @@ Gtk.ListBoxRow .menu-button:hover {
   	color: inherit;
 }
 
+.loved-button {
+	box-shadow: none;
+	padding-top: 0;
+	padding-bottom: 0;
+	background-image: none;
+	color: inherit;
+}
+
+.loved-button:hover {
+	border-color: alpha(@theme_fg_color, 0.1);
+	color: inherit;
+}

--- a/data/lollypop.gresource.xml
+++ b/data/lollypop.gresource.xml
@@ -9,6 +9,7 @@
     <file preprocess="xml-stripblanks">AlbumRow.ui</file>
     <file preprocess="xml-stripblanks">QueuePopover.ui</file>
     <file preprocess="xml-stripblanks">RatingWidget.ui</file>
+    <file preprocess="xml-stripblanks">LovedWidget.ui</file>
     <file preprocess="xml-stripblanks">RadioWidget.ui</file>
     <file preprocess="xml-stripblanks">RadiosView.ui</file>
     <file preprocess="xml-stripblanks">RadioPopover.ui</file>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,6 +64,7 @@ app_PYTHON = \
     view_radios.py\
     widgets_album.py\
     widgets_device.py\
+    widgets_loved.py\
     widgets_playlist.py\
     widgets_radio.py\
     widgets_rating.py\

--- a/src/pop_infos.py
+++ b/src/pop_infos.py
@@ -18,6 +18,7 @@ from threading import Thread
 from cgi import escape
 
 from lollypop.define import Lp
+from lollypop import utils
 
 
 class InfosPopover(Gtk.Popover):
@@ -242,11 +243,7 @@ class ArtistInfos(Gtk.Bin):
         """
         sql = Lp.db.get_cursor()
         if self._track_id is not None:
-            if Lp.playlists.is_present(Lp.playlists._LOVED,
-                                       self._track_id,
-                                       None,
-                                       False,
-                                       sql):
+            if utils.is_loved(self._track_id, sql=sql):
                 self._liked = False
                 self._love_btn.set_tooltip_text(_("I do not love"))
                 self._love_btn.set_image(
@@ -265,13 +262,8 @@ class ArtistInfos(Gtk.Bin):
         # Add track to Liked tracks
         sql = Lp.db.get_cursor()
         if self._track_id is not None:
-            Lp.playlists.add_track(Lp.playlists._LOVED,
-                                   Lp.tracks.get_path(self._track_id,
-                                                      sql))
+            utils.set_loved(self._track_id, True, sql=sql)
         sql.close()
-
-        if Lp.lastfm is not None:
-            Lp.lastfm.love(self._artist, self._title)
 
     def _unlove_track(self):
         """
@@ -282,12 +274,8 @@ class ArtistInfos(Gtk.Bin):
         # Del track from Liked tracks
         sql = Lp.db.get_cursor()
         if self._track_id is not None:
-            Lp.playlists.remove_tracks(
-                Lp.playlists._LOVED,
-                [Lp.tracks.get_path(self._track_id, sql)])
+            utils.set_loved(self._track_id, False, sql=sql)
         sql.close()
-        if Lp.lastfm is not None:
-            Lp.lastfm.unlove(self._artist, self._title)
 
     def _on_love_btn_clicked(self, btn):
         """

--- a/src/pop_menu.py
+++ b/src/pop_menu.py
@@ -270,19 +270,6 @@ class PlaylistsMenu(BaseMenu):
                 self.append(_("Add to \"%s\"") % playlist,
                             "app.playlist%s" % i)
             i += 1
-        if not self._is_album:
-            action = Gio.SimpleAction(name="loved")
-            self._app.add_action(action)
-            if utils.is_loved(self._object_id):
-                action.connect('activate',
-                               self._del_from_loved)
-                self.append(_("I dislove this track"),
-                            "app.loved")
-            else:
-                action.connect('activate',
-                               self._add_to_loved)
-                self.append(_("I love this track"),
-                            "app.loved")
 
     def _add_to_playlists(self, action, variant):
         """

--- a/src/pop_menu.py
+++ b/src/pop_menu.py
@@ -17,6 +17,7 @@ from gettext import gettext as _
 from threading import Thread
 
 from lollypop.define import Lp, NextContext, Type
+from lollypop import utils
 
 
 class BaseMenu(Gio.Menu):
@@ -272,10 +273,7 @@ class PlaylistsMenu(BaseMenu):
         if not self._is_album:
             action = Gio.SimpleAction(name="loved")
             self._app.add_action(action)
-            if Lp.playlists.is_present(Lp.playlists._LOVED,
-                                       self._object_id,
-                                       None,
-                                       False):
+            if utils.is_loved(self._object_id):
                 action.connect('activate',
                                self._del_from_loved)
                 self.append(_("I dislove this track"),
@@ -341,30 +339,7 @@ class PlaylistsMenu(BaseMenu):
             @param GVariant
             @param playlist name as str
         """
-        Lp.playlists.add_track(Lp.playlists._LOVED,
-                               Lp.tracks.get_path(self._object_id))
-        if Lp.lastfm is not None:
-            t = Thread(target=self._add_to_loved_on_lastfm)
-            t.daemon = True
-            t.start()
-
-    def _add_to_loved_on_lastfm(self):
-        """
-            Add to loved on lastfm
-        """
-        sql = Lp.db.get_cursor()
-        # Love the track on lastfm
-        if Gio.NetworkMonitor.get_default().get_network_available() and\
-           Lp.lastfm.is_auth():
-            title = Lp.tracks.get_name(self._object_id, sql)
-            album_id = Lp.tracks.get_album_id(self._object_id, sql)
-            artist_id = Lp.albums.get_artist_id(album_id, sql)
-            if artist_id == Type.COMPILATIONS:
-                artist = Lp.tracks.get_artist_names(self._object_id, sql)
-            else:
-                artist = Lp.artists.get_name(artist_id, sql)
-            Lp.lastfm.love(artist, title)
-        sql.close()
+        utils.set_loved(self._object_id, True)
 
     def _del_from_loved(self, action, variant):
         """
@@ -373,30 +348,7 @@ class PlaylistsMenu(BaseMenu):
             @param GVariant
             @param playlist name as str
         """
-        Lp.playlists.remove_tracks(Lp.playlists._LOVED,
-                                   [Lp.tracks.get_path(self._object_id)])
-        if Lp.lastfm is not None:
-            t = Thread(target=self._del_from_loved_on_lastfm)
-            t.daemon = True
-            t.start()
-
-    def _del_from_loved_on_lastfm(self):
-        """
-            Remove from loved on lastfm
-        """
-        sql = Lp.db.get_cursor()
-        # Love the track on lastfm
-        if Gio.NetworkMonitor.get_default().get_network_available() and\
-           Lp.lastfm.is_auth():
-            title = Lp.tracks.get_name(self._object_id, sql)
-            album_id = Lp.tracks.get_album_id(self._object_id, sql)
-            artist_id = Lp.albums.get_artist_id(album_id, sql)
-            if artist_id == Type.COMPILATIONS:
-                artist = Lp.tracks.get_artist_names(self._object_id, sql)
-            else:
-                artist = Lp.artists.get_name(artist_id, sql)
-            Lp.lastfm.unlove(artist, title)
-        sql.close()
+        utils.set_loved(self._object_id, False)
 
 
 class PopToolbarMenu(Gio.Menu):

--- a/src/utils.py
+++ b/src/utils.py
@@ -14,7 +14,7 @@ from gi.repository import Gio
 
 from lollypop.define import Lp
 from gettext import gettext as _
-from _thread import start_new_thread
+from threading import Thread
 import os
 
 
@@ -151,15 +151,17 @@ def set_loved(track_id, loved, sql=None):
             Lp.playlists.add_track(Lp.playlists._LOVED,
                                    Lp.tracks.get_path(track_id, sql))
             if Lp.lastfm is not None:
-                start_new_thread(_set_loved_on_lastfm,
-                                 (track_id, True, sql))
+                t = Thread(target=_set_loved_on_lastfm, args=(track_id, True, sql))
+                t.daemon = True
+                t.start()
     else:
         if not loved:
             Lp.playlists.remove_tracks(Lp.playlists._LOVED,
                                        [Lp.tracks.get_path(track_id, sql)])
             if Lp.lastfm is not None:
-                start_new_thread(_set_loved_on_lastfm,
-                                 (track_id, False, sql))
+                t = Thread(target=_set_loved_on_lastfm, args=(track_id, False, sql))
+                t.daemon = True
+                t.start()
 
     sql.close()
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -123,61 +123,62 @@ def rgba_to_hex(color):
                                            int(color.blue * 255))
 
 
-def is_loved(object_id, genre_id=None, is_album=False, sql=None):
+def is_loved(track_id, genre_id=None, is_album=False, sql=None):
     """
         Check if object is in loved playlist
-        @param object_id
+        @param track_id
         @param genre_id
         @param is_album
         @return bool
     """
     return Lp.playlists.is_present(Lp.playlists._LOVED,
-                                   object_id,
+                                   track_id,
                                    genre_id,
                                    is_album,
                                    sql)
 
-def set_loved(object_id, loved, sql=None):
+def set_loved(track_id, loved, sql=None):
     """
-        Add or remove object from loved playlist
-        @param object_id
+        Add or remove track from loved playlist
+        @param track_id
         @param loved Add to loved playlist if `True`; remove if `False`
     """
     if sql is None:
         sql = Lp.db.get_cursor()
 
-    if not is_loved(object_id):
+    if not is_loved(track_id):
         if loved:
             Lp.playlists.add_track(Lp.playlists._LOVED,
-                                   Lp.tracks.get_path(object_id, sql))
+                                   Lp.tracks.get_path(track_id, sql))
             if Lp.lastfm is not None:
                 start_new_thread(_set_loved_on_lastfm,
-                                 (object_id, True, sql))
+                                 (track_id, True, sql))
     else:
         if not loved:
             Lp.playlists.remove_tracks(Lp.playlists._LOVED,
-                                       [Lp.tracks.get_path(object_id, sql)])
+                                       [Lp.tracks.get_path(track_id, sql)])
             if Lp.lastfm is not None:
                 start_new_thread(_set_loved_on_lastfm,
-                                 (object_id, False, sql))
+                                 (track_id, False, sql))
 
     sql.close()
 
-def _set_loved_on_lastfm(object_id, loved, sql):
+def _set_loved_on_lastfm(track_id, loved, sql):
     """
-        Add or remove object from loved playlist on Last.fm
-        @param object_id
+        Add or remove track from loved playlist on Last.fm
+        @param track_id
         @param loved Add to loved playlist if `True`; remove if `False`
     """
     # Love the track on lastfm
     if Gio.NetworkMonitor.get_default().get_network_available() and\
             Lp.lastfm.is_auth():
-        title = Lp.tracks.get_name(object_id, sql)
-        album_id = Lp.tracks.get_album_id(object_id, sql)
+        Track
+        title = Lp.tracks.get_name(track_id, sql)
+        album_id = Lp.tracks.get_album_id(track_id, sql)
         artist_id = Lp.albums.get_artist_id(album_id, sql)
 
         if artist_id == Type.COMPILATIONS:
-            artist = Lp.tracks.get_artist_names(object_id, sql)
+            artist = Lp.tracks.get_artist_names(track_id, sql)
         else:
             artist = Lp.artists.get_name(artist_id, sql)
 

--- a/src/widgets_loved.py
+++ b/src/widgets_loved.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2014-2015 Cedric Bellegarde <cedric.bellegarde@adishatz.org>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from gi.repository import Gtk
+
+from lollypop.define import Lp
+from lollypop.utils import is_loved, set_loved
+
+
+class LovedWidget(Gtk.Bin):
+    """
+        Loved widget
+    """
+
+    def __init__(self, track_id):
+        """
+            Init widget
+            @param track_id as int
+        """
+        Gtk.Bin.__init__(self)
+        self._track_id = track_id
+        builder = Gtk.Builder()
+        builder.add_from_resource('/org/gnome/Lollypop/LovedWidget.ui')
+        builder.connect_signals(self)
+
+        self.add(builder.get_object('widget'))
+        self.set_opacity(0.6 if is_loved(track_id) else 0.1)
+
+#######################
+# PRIVATE             #
+#######################
+
+    def _on_button_press(self, widget, event):
+        """
+            On button press, toggle loved status
+            @param widget as Gtk.EventBox
+            @param event as Gdk.Event
+        """
+        loved = not is_loved(self._track_id)
+        set_loved(self._track_id, loved)
+        self.set_opacity(0.6 if loved else 0.1)
+

--- a/src/widgets_track.py
+++ b/src/widgets_track.py
@@ -17,6 +17,8 @@ from lollypop.pop_menu import TrackMenu
 from lollypop.widgets_rating import RatingWidget
 from lollypop.utils import seconds_to_string, rgba_to_hex
 from lollypop.objects import Track, Album
+from lollypop import utils
+
 
 
 class Row(Gtk.ListBoxRow):
@@ -214,6 +216,7 @@ class TrackRow(Row):
         self._builder = Gtk.Builder()
         self._builder.add_from_resource('/org/gnome/Lollypop/TrackRow.ui')
         self._builder.connect_signals(self)
+        self._loved_img = self._builder.get_object('image2')
         self._menu_btn = self._builder.get_object('menu')
         Row.__init__(self)
 
@@ -224,6 +227,12 @@ class TrackRow(Row):
         """
         Row.set_object_id(self, object_id)
         self._object = Track(self._object_id)
+
+    def set_loved(self, loved):
+        """
+            Set loved
+        """
+        self._loved_img.set_opacity(0.6 if loved else 0.2)
 
     def show_menu(self, show):
         """
@@ -247,7 +256,7 @@ class TrackRow(Row):
             window = widget.get_window()
             if window == event.window:
                 self._popup_menu(widget, event.x, event.y)
-            # Happen when pressing button over menu btn
+            # Happens when pressing button over menu btn
             else:
                 self._popup_menu(self._menu_btn)
             return True
@@ -258,6 +267,18 @@ class TrackRow(Row):
             @param widget as Gtk.Button
         """
         self._popup_menu(widget)
+
+    def _on_loved_btn_clicked(self, widget):
+        """
+            Toggle track love
+            @param widget as Gtk.Button
+        """
+        if utils.is_loved(self._object_id):
+            utils.set_loved(self._object_id, False)
+            self.set_loved(False)
+        else:
+            utils.set_loved(self._object_id, True)
+            self.set_loved(True)
 
     def _popup_menu(self, widget, xcoordinate=None, ycoordinate=None):
         """
@@ -341,6 +362,8 @@ class TracksWidget(Gtk.ListBox):
         track_row.show_menu(self._show_menu)
         if Lp.player.current_track.id == track_id:
             track_row.show_icon(True)
+        if utils.is_loved(track_id):
+            track_row.set_loved(True)
         if pos:
             track_row.set_num_label(
                 '''<span foreground="%s"

--- a/src/widgets_track.py
+++ b/src/widgets_track.py
@@ -15,6 +15,7 @@ from gi.repository import GObject, Gtk
 from lollypop.define import Lp, ArtSize
 from lollypop.pop_menu import TrackMenu
 from lollypop.widgets_rating import RatingWidget
+from lollypop.widgets_loved import LovedWidget
 from lollypop.utils import seconds_to_string, rgba_to_hex
 from lollypop.objects import Track, Album
 from lollypop import utils
@@ -284,23 +285,36 @@ class TrackRow(Row):
             rect.width = 1
             rect.height = 1
             popover.set_pointing_to(rect)
+
         rating = RatingWidget(self._object)
         rating.set_property('margin_top', 5)
         rating.set_property('margin_bottom', 5)
         rating.show()
+
+        loved = LovedWidget(self._object_id)
+        loved.set_margin_top(5)
+        loved.set_margin_bottom(5)
+        loved.show()
+
         # Hack to add two widgets in popover
         # Use a Gtk.PopoverMenu later (GTK>3.16 available on Debian stable)
-        stack = Gtk.Stack()
         grid = Gtk.Grid()
         grid.set_orientation(Gtk.Orientation.VERTICAL)
+
+        stack = Gtk.Stack()
         stack.add_named(grid, 'main')
         stack.show_all()
+
         menu_widget = popover.get_child()
         menu_widget.reparent(grid)
+
         separator = Gtk.Separator()
         separator.show()
+
         grid.add(separator)
         grid.add(rating)
+        grid.add(loved)
+
         popover.add(stack)
         popover.connect('closed', self._on_closed)
         self.get_style_context().add_class('track-menu-selected')
@@ -311,6 +325,7 @@ class TrackRow(Row):
             Remove selected style
             @param widget as Gtk.Popover
         """
+        self.set_loved(utils.is_loved(self._object_id))
         self.get_style_context().remove_class('track-menu-selected')
 
 

--- a/src/widgets_track.py
+++ b/src/widgets_track.py
@@ -216,7 +216,7 @@ class TrackRow(Row):
         self._builder = Gtk.Builder()
         self._builder.add_from_resource('/org/gnome/Lollypop/TrackRow.ui')
         self._builder.connect_signals(self)
-        self._loved_img = self._builder.get_object('image2')
+        self._loved_img = self._builder.get_object('loved')
         self._menu_btn = self._builder.get_object('menu')
         Row.__init__(self)
 
@@ -232,7 +232,7 @@ class TrackRow(Row):
         """
             Set loved
         """
-        self._loved_img.set_opacity(0.6 if loved else 0.2)
+        self._loved_img.set_opacity(0.6 if loved else 0.1)
 
     def show_menu(self, show):
         """
@@ -267,18 +267,6 @@ class TrackRow(Row):
             @param widget as Gtk.Button
         """
         self._popup_menu(widget)
-
-    def _on_loved_btn_clicked(self, widget):
-        """
-            Toggle track love
-            @param widget as Gtk.Button
-        """
-        if utils.is_loved(self._object_id):
-            utils.set_loved(self._object_id, False)
-            self.set_loved(False)
-        else:
-            utils.set_loved(self._object_id, True)
-            self.set_loved(True)
 
     def _popup_menu(self, widget, xcoordinate=None, ycoordinate=None):
         """


### PR DESCRIPTION
Adding and removing tracks to the "loved tracks" playlist is too tedious; there is also no indication on the UI that a track is loved or not. I think this would be a useful feature to add. This PR adds a crude implementation of loved/unloved indicators and toggles. I did not think about looks since I suck at it. Also, I'm not a Python programmer so hit me up if you see a better way to do this, whether this gets in or not :smile: 

![screenshot from 2015-08-22 23-19-47](https://cloud.githubusercontent.com/assets/2820998/9426123/5a0e0a34-4924-11e5-8dcd-c73ff5a74756.png)