### PR TITLE
Fixed missing Russian translation in po/LINGUAS

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -12,6 +12,7 @@ it
 nl
 pl
 pt_BR
+ru
 sk
 sr
 sr@latin


### PR DESCRIPTION
I've added Russian translation to the po/LINGUAS because Lollypop is translated into Russian but not available in Russian because it's not defined in LINGUAS file that it's translated.

Tested it, works fine. Just compile Lollypop, sudo make install it, and run it with: 

```
LANG=ru_RU.UTF-8 lollypop
```