### PR TITLE
Fixed MTP sync removing synced trackes

### DIFF
--- a/src/sync_mtp.py
+++ b/src/sync_mtp.py
@@ -84,7 +84,18 @@ class MtpSync:
                 if info.get_file_type() == Gio.FileType.DIRECTORY:
                     dir_uris.append(uri+'/'+info.get_name())
                 else:
-                    children.append(uri+'/'+info.get_name())
+                    album_name = uri.replace(self._uri+"/tracks/", "")
+                    album =  GLib.uri_escape_string(album_name,
+                                                    "",
+                                                    False)
+                    track = GLib.uri_escape_string(info.get_name(),
+                                                    "",
+                                                    False)
+
+
+                    children.append("%s/tracks/%s/%s" % (self._uri,
+                                                        album,
+                                                        track))
         return children
 
     def _sync(self, playlists):


### PR DESCRIPTION
I thought I'd have a go at fixing #412 

The `_remove_from_device` function sanitizes album and track names when it's putting together a list of files for playlists to be synced. Later on in the function when it puts together a list of files on the device, it does not sanitize album and track names.

One list shows a track as:
`02%20-%20Kryptic%20Minds%20-%20Hybrid%20%29Biome Remix%29`

And the other list shows the track as:
`02 - Kryptic Minds - Hybrid (Biome Remix)`

Due to the name mismatch, when it compares the 2 lists, it concludes that the tracks on the device aren't part of any playlist and removes it. I've extended the `_get_children_uris` function to sanitize album and track names. I've tested it on my devices and it's working as expected.