### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,31 @@ $ ./autogen.sh
 $ make
 # make install
 ```
+
+In case you want the integration with [Last.fm](http://last.fm) to work you need to install `pylast`
+```
+# apt-get install python3-pip
+# pip3 install pylast
+```
+
+### On Debian (Jessie)
+```
+$ git clone https://github.com/gnumdk/lollypop.git
+$ cd lollypop
+# apt-get install autoconf
+# apt-get install libglib2.0-dev
+# apt-get install intltool
+# apt-get install yelp-tools 
+# apt-get install libgirepository1.0-dev
+# apt-get install libgtk-3-dev
+$ ./autogen.sh
+$ make
+# make install
+```
+
+Instead of `make install` you might want to use `checkinstall`
+```
+# apt-get checkinstall
+# checkinstall
+```
+This will allow you to uninstall Lollypop as a package, for example with `apt-get uninstall lollypop`.


### PR DESCRIPTION
I was trying to install Lollypop on Debian Jessie. The PPA did not work so I built from source. For that I had to figure which new packages to install. I noted down the names of the packages I installed and gathered the information in this commit.

---
The PPA installation method resulted in the following 404 error

```
sudo apt-get update
...
W: Failed to fetch http://ppa.launchpad.net/gnumdk/lollypop/ubuntu/dists/jessie/main/binary-amd64/Packages: 404  Not Found
W: Failed to fetch http://ppa.launchpad.net/gnumdk/lollypop/ubuntu/dists/jessie/main/binary-i386/Packages: 404  Not Found
```