### PR TITLE
Break from loop if a `tag–editor` is found on `PATH`

### DIFF
--- a/src/widgets_context.py
+++ b/src/widgets_context.py
@@ -112,6 +112,7 @@ class ContextWidget(Gtk.Grid):
             for editor in [favorite] + TAG_EDITORS:
                 if GLib.find_program_in_path(editor) is not None:
                     self.__tag_editor = editor
+                    break
             if self.__tag_editor is not None:
                 edit = HoverWidget('document-properties-symbolic',
                                    self.__edit_tags)


### PR DESCRIPTION
In the current implementation, the __last__ tag–editor that is found is used. 

If a favorite editor is set, it is ignored, if another editor is found later on in the loop. 
This patch changes that behavior, so that the first editor that is found is used.