### PR TITLE
Fix not being able to convert "hi-res" audio files.

### DIFF
--- a/src/sync_mtp.py
+++ b/src/sync_mtp.py
@@ -475,7 +475,7 @@ class MtpSync:
                             'filesrc location="%s" ! decodebin\
                             ! audioconvert\
                             ! audioresample\
-                            ! audio/x-raw,format=S16LE,rate=44100,channels=2\
+                            ! audio/x-raw,rate=44100,channels=2\
                             ! rgvolume pre-amp=6.0 headroom=10.0\
                             ! rglimiter ! audioconvert\
                             ! lamemp3enc target=quality quality=%s ! id3v2mux\
@@ -486,7 +486,7 @@ class MtpSync:
                             'filesrc location="%s" ! decodebin\
                             ! audioconvert\
                             ! audioresample\
-                            ! audio/x-raw,format=S16LE,rate=44100,channels=2\
+                            ! audio/x-raw,rate=44100,channels=2\
                             ! lamemp3enc target=quality quality=%s\
                             ! id3v2mux\
                             ! filesink location="%s"'

--- a/src/sync_mtp.py
+++ b/src/sync_mtp.py
@@ -474,6 +474,8 @@ class MtpSync:
                 pipeline = Gst.parse_launch(
                             'filesrc location="%s" ! decodebin\
                             ! audioconvert\
+                            ! audioresample\
+                            ! audio/x-raw,format=S16LE,rate=44100,channels=2\
                             ! rgvolume pre-amp=6.0 headroom=10.0\
                             ! rglimiter ! audioconvert\
                             ! lamemp3enc target=quality quality=%s ! id3v2mux\
@@ -483,6 +485,8 @@ class MtpSync:
                 pipeline = Gst.parse_launch(
                             'filesrc location="%s" ! decodebin\
                             ! audioconvert\
+                            ! audioresample\
+                            ! audio/x-raw,format=S16LE,rate=44100,channels=2\
                             ! lamemp3enc target=quality quality=%s\
                             ! id3v2mux\
                             ! filesink location="%s"'


### PR DESCRIPTION
Previously, if you attempted to sync a file with a higher-than-CD sample rate (eg. 96KHz) with mp3 conversion on, syncing would freeze. This fixes that by re-sampling files before conversion.