### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Lollypop
+# Lollypop
 
 
 Lollypop is a new GNOME music playing application.
@@ -30,7 +30,7 @@ It provides:
 - HiDPI support
 - Tunein support
 
-##Depends on
+## Depends on
 - gtk3 >= 3.14
 - gobject-introspection
 - gir1.2-gstreamer-1.0 (Debian)
@@ -45,7 +45,7 @@ It provides:
 - python-sqlite
 - python-pylast >= 1.0
 
-##Building from git
+## Building from git
 ```
 $ git clone https://github.com/gnumdk/lollypop.git
 $ cd lollypop


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
