### PR TITLE
Keep MPRIS interface in microseconds

### DIFF
--- a/src/mpris.py
+++ b/src/mpris.py
@@ -204,7 +204,7 @@ class MPRIS(Server):
             Lp().player.play()
 
     def SetPosition(self, track_id, position):
-        Lp().player.seek(position / Gst.SECOND)
+        Lp().player.seek(position / (1000 * 1000))
 
     def OpenUri(self, uri):
         pass
@@ -212,7 +212,7 @@ class MPRIS(Server):
     def Seek(self, offset):
         # Convert position in seconds
         position = Lp().player.position / Gst.SECOND
-        Lp().player.seek(position + offset / Gst.SECOND)
+        Lp().player.seek(position + offset / (1000 * 1000))
 
     def Seeked(self, position):
         self.__bus.emit_signal(
@@ -249,7 +249,7 @@ class MPRIS(Server):
         elif property_name == "Volume":
             return GLib.Variant("d", Lp().player.volume)
         elif property_name == "Position":
-            return GLib.Variant("x", Lp().player.position)
+            return GLib.Variant("x", Lp().player.position / Gst.SECOND * (1000 * 1000))
         elif property_name in ["CanGoNext", "CanGoPrevious",
                                "CanPlay", "CanPause"]:
             return GLib.Variant("b", Lp().player.current_track.id is not None)
@@ -346,7 +346,7 @@ class MPRIS(Server):
                                        Lp().player.current_track.album_artists)
             self.__metadata["mpris:length"] = GLib.Variant(
                                "x",
-                               Lp().player.current_track.duration * Gst.SECOND)
+                               Lp().player.current_track.duration * (1000 * 1000))
             self.__metadata["xesam:genre"] = GLib.Variant(
                                               "as",
                                               Lp().player.current_track.genres)
@@ -380,7 +380,7 @@ class MPRIS(Server):
                 self.__metadata["mpris:artUrl"] = GLib.Variant("s", "")
 
     def __on_seeked(self, player, position):
-        self.Seeked(position * Gst.SECOND)
+        self.Seeked(position * (1000 * 1000))
 
     def __on_volume_changed(self, player, data=None):
         self.PropertiesChanged(self.__MPRIS_PLAYER_IFACE,

--- a/src/mpris_legacy.py
+++ b/src/mpris_legacy.py
@@ -83,7 +83,7 @@ class MPRIS(dbus.service.Object):
     @dbus.service.method(dbus_interface=MPRIS_PLAYER_IFACE,
                          in_signature="ox")
     def SetPosition(self, track_id, position):
-        Lp().player.seek(position/Gst.SECOND)
+        Lp().player.seek(position/(1000 * 1000))
 
     @dbus.service.method(dbus_interface=MPRIS_PLAYER_IFACE,
                          in_signature="s")
@@ -119,7 +119,7 @@ class MPRIS(dbus.service.Object):
                 "Shuffle": True,
                 "Metadata": dbus.Dictionary(self._metadata, signature="sv"),
                 "Volume": dbus.Double(Lp().player.volume),
-                "Position": dbus.Int64(Lp().player.position),
+                "Position": dbus.Int64(Lp().player.position / Gst.SECOND * (1000 * 1000)),
                 "MinimumRate": dbus.Double(1.0),
                 "MaximumRate": dbus.Double(1.0),
                 "CanGoNext": True,
@@ -183,7 +183,7 @@ class MPRIS(dbus.service.Object):
             self._metadata["xesam:albumArtist"] = \
                 ", ".join(Lp().player.current_track.album_artists)
             self._metadata["mpris:length"] = dbus.Int64(
-                Lp().player.current_track.duration * Gst.SECOND)
+                Lp().player.current_track.duration * (1000 * 1000))
             self._metadata["xesam:genre"] = Lp().player.current_track.genres\
                 or "Web"
             self._metadata["xesam:url"] = Lp().player.current_track.uri
@@ -212,7 +212,7 @@ class MPRIS(dbus.service.Object):
                 self._metadata["mpris:artUrl"] = ""
 
     def _on_seeked(self, player, position):
-        self.Seeked(position * Gst.SECOND)
+        self.Seeked(position * (1000 * 1000))
 
     def _on_volume_changed(self, player, data=None):
         self.PropertiesChanged(self.MPRIS_PLAYER_IFACE,


### PR DESCRIPTION
In switching to seconds for everything internally, the external mpris interface was inadvertently converted to nanoseconds instead of microseconds.

This PR converts all values at the MPRIS <-> Lollypop boundary from microseconds <-> seconds as needed.

*Edit: corrected milliseconds to nanoseconds*