### PR TITLE
Fix crash while scanning files for changes

### DIFF
--- a/lollypop/collectionscanner.py
+++ b/lollypop/collectionscanner.py
@@ -214,7 +214,7 @@ class CollectionScanner(GObject.GObject, TagReader):
                         if uri in orig_tracks:
                             orig_tracks.remove(uri)
                             i += 1
-                            if mtime <= mtimes[uri]:
+                            if mtime <= mtimes.get(uri, mtime + 1):
                                 i += 1
                                 continue
                             else:


### PR DESCRIPTION
The mtimes collection might not have an entry for said URI and this will cause the file to no be pushed in to the db. This makes sure that if we don't have a past mtime it will be considered as updated