### PR TITLE
application.py: allow users to escape the fullscreen mode using F7/F11

### DIFF
--- a/lollypop/application.py
+++ b/lollypop/application.py
@@ -148,7 +148,6 @@ class Application(Gtk.Application):
                                          None)
         except Exception as e:
             print("Application::init():", e)
-        self.__is_fs = False
 
         cssProviderFile = Lio.File.new_for_uri(
                 "resource:///org/gnome/Lollypop/application.css")
@@ -247,7 +246,7 @@ class Application(Gtk.Application):
         """
             Return True if application is fullscreen
         """
-        return self.__is_fs
+        return self.__fs is not None
 
     def set_mini(self, action, param):
         """
@@ -273,7 +272,7 @@ class Application(Gtk.Application):
         """
             Save window position and view
         """
-        if self.__is_fs:
+        if self.__fs:
             return
         if self.settings.get_value("save-state"):
             self.window.save_view_state()
@@ -522,13 +521,12 @@ class Application(Gtk.Application):
             @param action as Gio.SimpleAction
             @param param as GLib.Variant
         """
-        if self.window and not self.__is_fs:
+        if self.window and not self.__fs:
             from lollypop.fullscreen import FullScreen
             self.__fs = FullScreen(self, self.window)
             self.__fs.connect("destroy", self.__on_fs_destroyed)
-            self.__is_fs = True
             self.__fs.show()
-        elif self.window and self.__is_fs:
+        elif self.window and self.__fs:
             self.__fs.destroy()
 
     def __on_fs_destroyed(self, widget):
@@ -536,7 +534,7 @@ class Application(Gtk.Application):
             Mark fullscreen as False
             @param widget as Fullscreen
         """
-        self.__is_fs = False
+        self.__fs = None
         if not self.window.is_visible():
             self.quit(True)
 

--- a/lollypop/application.py
+++ b/lollypop/application.py
@@ -272,7 +272,7 @@ class Application(Gtk.Application):
         """
             Save window position and view
         """
-        if self.__fs:
+        if self.is_fullscreen():
             return
         if self.settings.get_value("save-state"):
             self.window.save_view_state()
@@ -521,12 +521,12 @@ class Application(Gtk.Application):
             @param action as Gio.SimpleAction
             @param param as GLib.Variant
         """
-        if self.window and not self.__fs:
+        if self.window and not self.is_fullscreen():
             from lollypop.fullscreen import FullScreen
             self.__fs = FullScreen(self, self.window)
             self.__fs.connect("destroy", self.__on_fs_destroyed)
             self.__fs.show()
-        elif self.window and self.__fs:
+        elif self.window and self.is_fullscreen():
             self.__fs.destroy()
 
     def __on_fs_destroyed(self, widget):

--- a/lollypop/application.py
+++ b/lollypop/application.py
@@ -93,6 +93,7 @@ class Application(Gtk.Application):
         self.notify = None
         self.lastfm = None
         self.debug = False
+        self.__fs = None
         self.__externals_count = 0
         self.__init_proxy()
         GLib.set_application_name("Lollypop")
@@ -523,10 +524,12 @@ class Application(Gtk.Application):
         """
         if self.window and not self.__is_fs:
             from lollypop.fullscreen import FullScreen
-            fs = FullScreen(self, self.window)
-            fs.connect("destroy", self.__on_fs_destroyed)
+            self.__fs = FullScreen(self, self.window)
+            self.__fs.connect("destroy", self.__on_fs_destroyed)
             self.__is_fs = True
-            fs.show()
+            self.__fs.show()
+        elif self.window and self.__is_fs:
+            self.__fs.destroy()
 
     def __on_fs_destroyed(self, widget):
         """


### PR DESCRIPTION
First of all, lollypop is awesome :smile:. Keep up the good work!

Currently (c7f820f90aa25a7bc08565024faad0347d27316b), lollypop does not allow users to escape the fullscreen mode using the F7/F11 shortcuts. In most applications, such as web browsers, it is common that the same shortcut can be used to escape the fullscreen mode.

In short, this pull-request introduces small changes so that the fullscreen mode can be escaped using F7/F11. 

Cheers,
Alex

**Edit:**
I think the class Application could be refactored by eliminating the private instance variable `__is_fs` by using the public method `is_fullscreen()`. Moreover, the method `is_fullscreen()` could be adjusted (see below) to use the private instance variable `__fs` to check whether lollypop is in fullscreen mode.

```python
    def is_fullscreen(self):
        """
            Return True if application is fullscreen
        """
        return self.__fs is not None
```